### PR TITLE
Make lunch schedule consistent with f54b229c031b5bd62a75681d18d8a6a355bc609d

### DIFF
--- a/2017-speakers.md
+++ b/2017-speakers.md
@@ -36,7 +36,7 @@ permalink: /speakers/
         </tr>
         <tr>
           <td>13:00 &ndash; 13:45</td>
-          <td>Lunch Break<br/>Catered by the King's Head</td>
+          <td>Lunch Break</td>
         </tr>
         <tr>
           <td>13:45 &ndash; 14:40</td>
@@ -98,7 +98,7 @@ permalink: /speakers/
         </tr>
         <tr>
           <td>12:30 &ndash; 13:30</td>
-          <td>Lunch Break<br/>Catered by the King's Head</td>
+          <td>Lunch Break</td>
         </tr>
         <tr>
           <td>13:30 &ndash; 13:55</td>


### PR DESCRIPTION
Hi Friends,

Thanks for your amazing work lining up sponsors and making dinner meals and afternoon break appetizers a thing! You guys rock.

The schedule (http://bsideswpg.ca/speakers/) need this revision, currently says "Lunch Break Catered by the King's Head", on both Saturday and Sunday.